### PR TITLE
add checksum?

### DIFF
--- a/src/main/java/com/github/zk1931/pulsed/Node.java
+++ b/src/main/java/com/github/zk1931/pulsed/Node.java
@@ -46,6 +46,8 @@ public abstract class Node {
 
   public abstract boolean isDirectory();
 
+  public abstract long getChecksum();
+
   @Override
   public boolean equals(Object obj) {
     if (obj == null) {


### PR DESCRIPTION
Since for every update we'll propagate changes up to root node, we can add checksum for each node and verify the consistency by comparing the checksums.

FileNode:
`checksum = checksum(data, version, fullPath, sessionID)`

DirNode:
`checksum = checksum(version, fullPath, checksum(child1.checksum, child2.chekcusum... childn.checksum))`

In this case if we want to compare if two subtrees are same or not we just need to compare checksums of the roots nodes of the subtree are same or not.
