### PR TITLE
error while waiting

### DIFF
--- a/src/main/java/com/github/zk1931/pulsed/TreeHandler.java
+++ b/src/main/java/com/github/zk1931/pulsed/TreeHandler.java
@@ -63,7 +63,7 @@ public final class  TreeHandler extends HttpServlet {
         // watch/Put requests will be processed within single thread.
         long version = Long.parseLong(options.get("wait"));
         Command watch = new WatchCommand(path, version, recursive);
-        AsyncContext context = request.startAsync(request, response);
+        AsyncContext context = Utils.getContext(request, response);
         try {
           this.pd.proposeFlushRequest(watch, context);
         } catch (ZabException ex) {
@@ -91,7 +91,7 @@ public final class  TreeHandler extends HttpServlet {
       throws ServletException, IOException {
     String path = request.getPathInfo();
     Map<String, String> options = Utils.getQueries(request.getQueryString());
-    AsyncContext context = request.startAsync(request, response);
+    AsyncContext context = Utils.getContext(request, response);
     boolean recursive = false;
     if (options.containsKey("recursive")) {
       recursive = true;
@@ -124,7 +124,7 @@ public final class  TreeHandler extends HttpServlet {
       throws ServletException, IOException {
     String path = request.getPathInfo();
     Map<String, String> options = Utils.getQueries(request.getQueryString());
-    AsyncContext context = request.startAsync(request, response);
+    AsyncContext context = Utils.getContext(request, response);
     boolean recursive = false;
     if (options.containsKey("recursive")) {
       recursive = true;
@@ -143,7 +143,7 @@ public final class  TreeHandler extends HttpServlet {
       throws ServletException, IOException {
     String path = request.getPathInfo();
     Map<String, String> options = Utils.getQueries(request.getQueryString());
-    AsyncContext context = request.startAsync(request, response);
+    AsyncContext context = Utils.getContext(request, response);
     boolean recursive = false;
     if (options.containsKey("recursive")) {
       recursive = true;

--- a/src/main/java/com/github/zk1931/pulsed/Utils.java
+++ b/src/main/java/com/github/zk1931/pulsed/Utils.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,14 @@ public final class Utils {
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
   private Utils() {}
+
+  public static AsyncContext getContext(HttpServletRequest request,
+                                        HttpServletResponse response) {
+    AsyncContext context = request.startAsync(request, response);
+    // No timeout.
+    context.setTimeout(0);
+    return context;
+  }
 
   public static String toJson(Object obj) {
     GsonBuilder builder = new GsonBuilder();


### PR DESCRIPTION
i don't remember the exact sequence of commands i sent, but i think this happened when i canceled some wait requests. i guess the server needs to check if the client has already canceled the request before trying to send watch response?

```
2014-12-06 13:34:50,702 ERROR Thread-13 c.g.zk1931.jzab.CommitProcessor:224 Caught exception in CommitProcessor!
java.lang.IllegalStateException: AsyncContext completed
        at org.eclipse.jetty.server.AsyncContextState.state(AsyncContextState.java:47) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.AsyncContextState.getResponse(AsyncContextState.java:138) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.pulsed.HttpWatch.trigger(HttpWatch.java:42) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.pulsed.WatchManager.triggerAndRemoveWatches(WatchManager.java:63) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.pulsed.DataTree.triggerWatches(DataTree.java:412) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.pulsed.DataTree.setData(DataTree.java:218) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.pulsed.PutCommand.execute(PutCommand.java:39) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.pulsed.PutCommand.executeAndReply(PutCommand.java:50) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.pulsed.Pulsed$PulsedStateMachine.deliver(Pulsed.java:121) ~[pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.jzab.CommitProcessor.deliverTxn(CommitProcessor.java:260) [pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.jzab.CommitProcessor.call(CommitProcessor.java:161) [pulsed-jar-with-dependencies.jar:na]
        at com.github.zk1931.jzab.CommitProcessor.call(CommitProcessor.java:46) [pulsed-jar-with-dependencies.jar:na]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_65]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_65]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_65]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_65]
2014-12-06 13:35:20,689 WARN  qtp1926492541-33 o.eclipse.jetty.server.HttpChannel:366 /michi2/test
java.io.EOFException: null
        at java.io.DataInputStream.readFully(DataInputStream.java:197) ~[na:1.7.0_65]
        at java.io.DataInputStream.readFully(DataInputStream.java:169) ~[na:1.7.0_65]
        at com.github.zk1931.pulsed.TreeHandler.doPut(TreeHandler.java:109) ~[pulsed-jar-with-dependencies.jar:na]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:710) ~[pulsed-jar-with-dependencies.jar:na]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:751) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:566) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:219) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1111) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:498) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:183) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1045) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:175) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:98) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.Server.handleAsync(Server.java:518) ~[pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:321) [pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.server.HttpChannel.run(HttpChannel.java:241) [pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:607) [pulsed-jar-with-dependencies.jar:na]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:536) [pulsed-jar-with-dependencies.jar:na]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_65]
```
