### PR TITLE
consistent name for 'dir' type

### DIFF
--- a/src/main/java/com/github/zk1931/pulsed/Utils.java
+++ b/src/main/java/com/github/zk1931/pulsed/Utils.java
@@ -37,6 +37,9 @@ public final class Utils {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
+  private static final String DIR_TYPE = "dir";
+  private static final String FILE_TYPE = "file";
+
   private Utils() {}
 
   public static String toJson(Object obj) {
@@ -51,9 +54,9 @@ public final class Utils {
 
   public static void writeHeader(Node node, HttpServletResponse response,
                                  AsyncContext context) {
-    String type = "file";
+    String type = FILE_TYPE;
     if (node instanceof DirNode) {
-      type = "directory";
+      type = DIR_TYPE;
     }
     response.addHeader("version", Long.toString(node.version));
     response.addHeader("type", type);
@@ -111,9 +114,9 @@ public final class Utils {
   }
 
   static void writeMetadata(Node node, JsonWriter writer) throws IOException {
-    String type = "file";
+    String type = FILE_TYPE;
     if (node instanceof DirNode) {
-      type = "directory";
+      type = DIR_TYPE;
     }
     writer.beginObject();
     writer.name("version").value(node.version);
@@ -130,7 +133,7 @@ public final class Utils {
     writer.name("version").value(node.version);
     writer.name("path").value(node.fullPath);
     writer.name("sessionID").value(node.sessionID);
-    writer.name("type").value("dir");
+    writer.name("type").value(DIR_TYPE);
     writer.name("checksum").value(Long.toHexString(node.getChecksum()));
     writer.name("children");
     writeChildren(node, writer, recursive);


### PR DESCRIPTION
the header says 'directory', but the body says 'dir'. the name should be consistent.

```
curl localhost:8080 -v
> GET / HTTP/1.1
> User-Agent: curl/7.32.0
> Host: localhost:8080
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Sat, 06 Dec 2014 20:52:16 GMT
< version: 0
< type: directory
< path: /
< checksum: 380030
< Content-Length: 111
< Server: Jetty(9.2.z-SNAPSHOT)
< 
{
  "version": 0,
  "path": "/",
  "sessionID": -1,
  "type": "dir",
  "checksum": "380030",
  "children": []
}
```
