### PR TITLE
don't return html for error response

### DIFF
--- a/src/main/java/com/github/zk1931/pulsed/Utils.java
+++ b/src/main/java/com/github/zk1931/pulsed/Utils.java
@@ -153,10 +153,7 @@ public final class Utils {
   public static void badRequest(HttpServletResponse response, String desc,
                                 AsyncContext ctx) {
     try {
-      response.setContentType("text/html");
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, desc);
-    } catch (IOException ex) {
-      LOG.warn("IOExcepion {}", ex);
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST, desc);
     } finally {
       if (ctx != null) {
         ctx.complete();
@@ -175,10 +172,7 @@ public final class Utils {
   public static void notFound(HttpServletResponse response, String desc,
                               AsyncContext ctx) {
     try {
-      response.setContentType("text/html");
-      response.sendError(HttpServletResponse.SC_NOT_FOUND, desc);
-    } catch (IOException ex) {
-      LOG.warn("IOExcepion {}", ex);
+      response.setStatus(HttpServletResponse.SC_NOT_FOUND, desc);
     } finally {
       if (ctx != null) {
         ctx.complete();


### PR DESCRIPTION
the response header already contains the error message (HTTP/1.1 404 /michi2 doesn't exist), so we probably don't need to return the html response. in the future we might want to return more detailed error message in json or something.

```
% curl localhost:8080/michi2/test -XPUT -d 'hello' -v
> PUT /michi2/test HTTP/1.1
> User-Agent: curl/7.32.0
> Host: localhost:8080
> Accept: */*
> Content-Length: 5
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 404 /michi2 doesn't exist
< Date: Sat, 06 Dec 2014 21:07:29 GMT
< Cache-Control: must-revalidate,no-cache,no-store
< Content-Type: text/html; charset=ISO-8859-1
< Content-Length: 301
< Server: Jetty(9.2.z-SNAPSHOT)
< 
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 404 </title>
</head>
<body>
<h2>HTTP ERROR: 404</h2>
<p>Problem accessing /michi2/test. Reason:
<pre>    /michi2 doesn't exist</pre></p>
<hr /><i><small>Powered by Jetty://</small></i>
</body>
</html>
```
