### PR TITLE
leave url-encoded string as is

### DIFF
--- a/src/main/java/com/github/zk1931/pulsed/TreeHandler.java
+++ b/src/main/java/com/github/zk1931/pulsed/TreeHandler.java
@@ -48,7 +48,7 @@ public final class  TreeHandler extends HttpServlet {
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
-    String path = request.getPathInfo();
+    String path = request.getRequestURI();
     DataTree tree = this.pd.getTree();
     Map<String, String> options = Utils.getQueries(request.getQueryString());
     boolean recursive = false;
@@ -89,7 +89,7 @@ public final class  TreeHandler extends HttpServlet {
   @Override
   protected void doPut(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
-    String path = request.getPathInfo();
+    String path = request.getRequestURI();
     Map<String, String> options = Utils.getQueries(request.getQueryString());
     AsyncContext context = Utils.getContext(request, response);
     boolean recursive = false;
@@ -122,7 +122,7 @@ public final class  TreeHandler extends HttpServlet {
   protected void doDelete(HttpServletRequest request,
                           HttpServletResponse response)
       throws ServletException, IOException {
-    String path = request.getPathInfo();
+    String path = request.getRequestURI();
     Map<String, String> options = Utils.getQueries(request.getQueryString());
     AsyncContext context = Utils.getContext(request, response);
     boolean recursive = false;
@@ -141,7 +141,7 @@ public final class  TreeHandler extends HttpServlet {
   protected void doPost(HttpServletRequest request,
                         HttpServletResponse response)
       throws ServletException, IOException {
-    String path = request.getPathInfo();
+    String path = request.getRequestURI();
     Map<String, String> options = Utils.getQueries(request.getQueryString());
     AsyncContext context = Utils.getContext(request, response);
     boolean recursive = false;


### PR DESCRIPTION
otherwise path might get corrupted when constructing response

```
% curl http://localhost:10000/%00 -XPUT -d test -v
> PUT /%00 HTTP/1.1
> User-Agent: curl/7.32.0
> Host: localhost:10000
> Accept: */*
> Content-Length: 4
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 200 OK
< Date: Sun, 07 Dec 2014 05:17:04 GMT
< version: 1
< type: file
< path: /
< checksum: 582409e9
< Content-Type: text/html
< Content-Length: 0
< Server: Jetty(9.2.z-SNAPSHOT)

% curl http://localhost:10000/%00 -v              
> GET /%00 HTTP/1.1
> User-Agent: curl/7.32.0
> Host: localhost:10000
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Sun, 07 Dec 2014 05:17:51 GMT
< version: 1
< type: file
< path: /
< checksum: 582409e9
< Content-Length: 4
< Server: Jetty(9.2.z-SNAPSHOT)
< 
test

% curl http://localhost:10000/ -v
> GET / HTTP/1.1
> User-Agent: curl/7.32.0
> Host: localhost:10000
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Sun, 07 Dec 2014 05:18:11 GMT
< version: 5
< type: directory
< path: /
< checksum: 3075045d
< Content-Length: 514
< Server: Jetty(9.2.z-SNAPSHOT)
< 
{
  "version": 5,
  "path": "/",
  "sessionID": -1,
  "type": "dir",
  "checksum": "3075045d",
  "children": [
    {
      "version": 1,
      "path": "/\u0000",
      "sessionID": -1,
      "type": "file",
      "checksum": "582409e9"
    }
  ]
}
```
