### PR TITLE
validate query parameters

### DIFF
--- a/src/main/java/com/github/zk1931/pulsed/Utils.java
+++ b/src/main/java/com/github/zk1931/pulsed/Utils.java
@@ -21,10 +21,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -208,41 +204,5 @@ public final class Utils {
       }
     }
     writer.endArray();
-  }
-
-  // Parse the query string and convert to key-value pairs.
-  //
-  // For example:
-  //
-  // if the query string is "wait=2&recursive" then it returns:
-  //    KEY         VALUE
-  //    -----------------
-  //    wait         2
-  //    recursive    null
-  //    -----------------
-  public static Map<String, String> getQueries(String queryString) {
-    if (queryString == null) {
-      return new HashMap<String, String>();
-    }
-    Map<String, String> queryMap = new HashMap<String, String>();
-    List<String> queries = Arrays.asList(queryString.split("&"));
-    for (String query : queries) {
-      String key;
-      String value;
-      int idx = query.indexOf("=");
-      if (idx == -1) {
-        key = query;
-        value = null;
-      } else {
-        key = query.substring(0, idx);
-        if (query.length() > idx + 1) {
-          value = query.substring(idx + 1, query.length());
-        } else {
-          value = null;
-        }
-      }
-      queryMap.put(key, value);
-    }
-    return queryMap;
   }
 }

--- a/src/test/python/test_single_server.py
+++ b/src/test/python/test_single_server.py
@@ -296,3 +296,21 @@ class TestSingleServer(object):
         path2 = res.headers["Location"]
 
         assert path2 > path1
+
+    def test_validate_query(self):
+        res = requests.get(self.baseurl)
+        assert res.status_code == 200
+        version = res.headers["version"]
+
+        res = requests.get(self.baseurl + "/?wait" + str(version))
+        assert res.status_code == 200
+
+        # invalid query.
+        res = requests.get(self.baseurl + "/?wait")
+        # bad query parameter
+        assert res.status_code == 400
+
+        # invalid query.
+        res = requests.get(self.baseurl + "/?wait=abc")
+        # bad query parameter
+        assert res.status_code == 400


### PR DESCRIPTION
we should return a 4xx error when the client send an invalid query parameter (e.g. GET /test?bad=parameter)
