### PR TITLE
handling location/path headers

### DIFF
--- a/src/main/java/com/github/zk1931/pulsed/CreateSeqFileCommand.java
+++ b/src/main/java/com/github/zk1931/pulsed/CreateSeqFileCommand.java
@@ -63,6 +63,9 @@ public class CreateSeqFileCommand extends Command {
     HttpServletResponse response = (HttpServletResponse)(context.getResponse());
     try {
       Node node = execute(tree);
+      // Since user has not idea of the path of newly craeted sequential node,
+      // we need return it to user.
+      response.addHeader("Location", node.fullPath);
       Utils.setHeader(node, response);
       Utils.replyCreated(response, context);
     } catch (PathNotExist ex) {

--- a/src/main/java/com/github/zk1931/pulsed/Utils.java
+++ b/src/main/java/com/github/zk1931/pulsed/Utils.java
@@ -64,7 +64,6 @@ public final class Utils {
     }
     response.addHeader("version", Long.toString(node.version));
     response.addHeader("type", type);
-    response.addHeader("path", node.fullPath);
     response.addHeader("checksum", String.format("%08X", node.getChecksum()));
   }
 


### PR DESCRIPTION
- response contains "Location" header if the location is not know to the client. 2 examples i can think of are sequential files and sessions.
- if the client already knows the location (e.g. GET /a/b/c), don't include location/path header in response.
